### PR TITLE
Fix Persian linter codepoint handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,11 @@ verification. Bundled Vazirmatn and Lalezar fonts (SIL OFL).
   placeholder colors only.
 - Run `python3 scripts/fa_lint.py --check` on any Persian example text you
   add to the docs — the skill must pass its own linter.
+- When documentation intentionally shows an invalid Persian form, mark the
+  following line with `<!-- fa-lint-ignore-next-line -->`. Do not use `--fix`
+  on intentional error examples.
+
+- The Persian linter must not report Unicode codepoint notation such as
+  `U+06CC`, `U+200C`, or `U+066A` as Latin digits. Codepoint notation may
+  appear inside Markdown punctuation or table cells, so detection must work
+  when the notation is part of a larger token.

--- a/references/orthography.md
+++ b/references/orthography.md
@@ -5,7 +5,7 @@ typed-in-a-hurry one. Readers may not name the rule, but they feel it. All of
 this is enforceable: `scripts/persian_cleanup.py --edit` fixes the mechanical
 layer automatically; `scripts/fa_lint.py --check` reports what needs judgment.
 
-## 1. ZWNJ — نیم‌فاصله (U+200C)
+## 1. ZWNJ: نیم‌فاصله (U+200C)
 
 The zero-width non-joiner separates morphemes *without* a visual gap while
 preventing letter joining. Writing a full space (or nothing) instead is the
@@ -16,19 +16,25 @@ Required ZWNJ positions:
 
 | Pattern | Wrong | Right |
 |---|---|---|
+<!-- fa-lint-ignore-next-line -->
 | می/نمی + verb | می شود، نمی توانم، میشود* | می‌شود، نمی‌توانم |
+<!-- fa-lint-ignore-next-line -->
 | Plural ها | کتاب ها، سایت های | کتاب‌ها، سایت‌های |
+<!-- fa-lint-ignore-next-line -->
 | تر / ترین | بزرگ تر، مهم ترین | بزرگ‌تر، مهم‌ترین |
+<!-- fa-lint-ignore-next-line -->
 | Enclitic pronouns after ه | خانه ام، پروژه اش | خانه‌ام، پروژه‌اش |
 | Compound prefixes | بی دقت، هم زمان | بی‌دقت، هم‌زمان |
 | Compound words | وب سایت، صفحه بندی، نرم افزار | وب‌سایت، صفحه‌بندی، نرم‌افزار |
+<!-- fa-lint-ignore-next-line -->
 | ای after ه | حرفه ای، هفته ای | حرفه‌ای، هفته‌ای |
 
+<!-- fa-lint-ignore-next-line -->
 *میشود (fully attached) is acceptable only in colloquial register (میشه);
 in formal text always می‌شود.
 
 Lexicalized exceptions stay solid: همکار، بهتر، کمتر، بیشتر، امروزه، آنها
-(آن‌ها also correct — pick one per document).
+(آن‌ها also correct; pick one per document).
 
 ## 2. Persian characters, not Arabic
 
@@ -37,12 +43,16 @@ codepoints, break search, and render dotted/undotted wrongly:
 
 | Use (Persian) | Never (Arabic) |
 |---|---|
+<!-- fa-lint-ignore-next-line -->
 | ی U+06CC | ي U+064A |
+<!-- fa-lint-ignore-next-line -->
 | ک U+06A9 | ك U+0643 |
+<!-- fa-lint-ignore-next-line -->
 | ۀ/هٔ (or ه‌ی) | ة U+0629 |
+<!-- fa-lint-ignore-next-line -->
 | ۴۵۶ U+06F4.. | ٤٥٦ U+0664.. |
 
-ه with hamza: خانهٔ من or خانه‌ی من — both accepted; be consistent per document.
+ه with hamza: خانهٔ من or خانه‌ی من. Both are accepted. Be consistent per document.
 
 ## 3. Digits
 
@@ -51,24 +61,30 @@ codepoints, break search, and render dotted/undotted wrongly:
 - Latin digits stay Latin inside: URLs, emails, phone numbers meant for
   international dialing (+98...), code, version strings (WordPress 6.5),
   file names.
+<!-- fa-lint-ignore-next-line -->
 - Never Arabic-Indic variants (٤ ٥ ٦).
 - Percent: «۲۰٪» (U+066A) or «۲۰ درصد». In RTL both orders render fine if the
   digits are Persian; with Latin digits «20%» the run flips LTR.
-- Thousands separator: ٬ (U+066C) or، comma-free spacing — one style per doc.
+- Thousands separator: ٬ (U+066C) or، comma-free spacing. Use one style per doc.
 
 ## 4. Punctuation
 
 | Persian | Replaces | Note |
 |---|---|---|
+<!-- fa-lint-ignore-next-line -->
 | ، U+060C | , | comma |
+<!-- fa-lint-ignore-next-line -->
 | ؛ U+061B | ; | semicolon |
+<!-- fa-lint-ignore-next-line -->
 | ؟ U+061F | ? | question mark |
+<!-- fa-lint-ignore-next-line -->
 | «...» | "..." | quotes (گیومه) |
 | … | ... | ellipsis, or سه‌نقطه |
 
 Rules:
 - No space *before* punctuation, one space *after*: «درست، مثل این.»
-- ! stays ! — but one, never !!!
+<!-- fa-lint-ignore-next-line -->
+- ! stays !. Use one, never !!!
 - Em/en dashes: not used in Persian prose. Use «،» «؛» ( ) or restructure.
 - Latin fragments inside Persian (brand names, code) keep Latin punctuation
   *inside the fragment*: «افزونه WooCommerce، نسخه‌ی ۹».
@@ -81,7 +97,7 @@ Write it explicitly only where the host word demands it:
 - After ا and و: صدای بلند، عموی من (the ی is mandatory)
 - Diacritic کسره (ِ) only for disambiguation in formal/educational text.
 
-### 5.1 هکسره — the error Iranians mock most
+### 5.1 هکسره: the error Iranians mock most
 
 Two different things sound identical at the end of a word, so writers swap them.
 Getting this wrong in public copy is the single fastest way to look careless:
@@ -89,7 +105,7 @@ Iranians screenshot هکسره mistakes off billboards and brand accounts for sp
 
 | | What it is | Written | Example |
 |---|---|---|---|
-| **کسره‌ی اضافه** | links a noun to what follows (ezafe) | kasre — usually left unwritten, never «ه» | کتابِ من / کتاب من |
+| **کسره‌ی اضافه** | links a noun to what follows (ezafe) | kasre, usually left unwritten, never «ه» | کتابِ من / کتاب من |
 | **«ـه» clitic** | colloquial short form of «است» (predicate) | attached «ه» | این کتابه = این کتاب است |
 
 **The test that always works:** replace the ending with «است» and read it aloud.
@@ -97,38 +113,43 @@ If the sentence still makes sense, the correct spelling is «ـه». If it turns
 nonsense, you need a kasre (and usually write nothing at all).
 
 - «این کتابه» ← «این کتاب است» ✓ → «ـه» correct
+<!-- fa-lint-ignore-next-line -->
 - «کتابه من» ← «کتاب است من» ✗ → ezafe needed: **کتابِ من** (or plain «کتاب من»)
 
 **Wrong → right:**
 
 | ❌ | ✅ | Why |
 |---|---|---|
+<!-- fa-lint-ignore-next-line -->
 | کتابه من رو ندیدی؟ | کتابِ من رو ندیدی؟ | ezafe, not «است» |
 | کلاسه زبان می‌رم | کلاسِ زبان می‌رم | ezafe |
+<!-- fa-lint-ignore-next-line -->
 | قیمته این محصول چنده؟ | قیمتِ این محصول چنده؟ | first is ezafe, second («چنده») is «است» ✓ |
+<!-- fa-lint-ignore-next-line -->
 | سایته شرکت بالا نمیاد | سایتِ شرکت بالا نمیاد | ezafe |
-| هوا خیلی خوبِ | هوا خیلی خوبه | predicate «است» — the reverse error |
+| هوا خیلی خوبِ | هوا خیلی خوبه | predicate «است». This is the reverse error. |
+<!-- fa-lint-ignore-next-line -->
 | ماشینه من خرابه | ماشینِ من خرابه | ezafe first, «است» second ✓ |
 
-**Careful — these are NOT errors.** Many nouns simply end in ه, and they take a
+**Careful: these are NOT errors.** Many nouns simply end in ه, and they take a
 normal ezafe like any other word: خانه، نامه، برنامه، پروژه، مقاله، هفته، تجربه،
 شماره، بچه. «نامه شما رسید» and «پروژه‌ی شما» are both fine; nothing was swapped.
 
 **Register note:** the «ـه» clitic belongs to colloquial writing only. In formal
-or academic text write «است» in full — «این کتاب است»، not «این کتابه». So a
+or academic text write «است» in full. Use «این کتاب است», not «این کتابه». So a
 formal document that contains «ـه» clitics has a register problem, not just an
 orthography one (see writing-style.md).
 
 `scripts/fa_lint.py --check` flags probable هکسره in both directions. It reports
 rather than auto-fixes, because only context decides which of two identical
-sounds the writer meant — and a wrong "fix" here changes the meaning.
+sounds the writer meant. A wrong "fix" here changes the meaning.
 
 ## 6. Spacing hygiene
 
 - Exactly one space between words; no double spaces (common AI artifact).
 - No space inside «گیومه» : «درست»، نه « غلط ».
 - Parentheses: بیرون فاصله، داخل نه (مثل این).
-- Latin↔Persian boundary: one space — «پلتفرم WordPress برای...».
+- Latin↔Persian boundary: one space: «پلتفرم WordPress برای...».
 
 ## 7. Numbers as words
 
@@ -141,11 +162,18 @@ Formal prose: one-word numbers under eleven often spelled out (سه پیشنها
 |---|---|---|
 | میخواهم | می‌خواهم | ZWNJ after می |
 | آنها را دیدم ولی کتابها نه | آن‌ها ... کتاب‌ها | ZWNJ before ها (if using آن‌ها style) |
+<!-- fa-lint-ignore-next-line -->
 | عليرضا | علیرضا | Arabic ي |
+<!-- fa-lint-ignore-next-line -->
 | لطفا | لطفاً | tanvin on Arabic loan |
-| گاهاً | گاهی | tanvin on Persian word — always wrong |
+<!-- fa-lint-ignore-next-line -->
+| گاهاً | گاهی | tanvin on Persian word; always wrong |
+<!-- fa-lint-ignore-next-line -->
 | دوماً | دوم اینکه / ثانیاً | same |
 | بсمت | به سمت / به‌سمت | mashed preposition |
+<!-- fa-lint-ignore-next-line -->
 | "نقل قول" | «نقل قول» | گیومه |
+<!-- fa-lint-ignore-next-line -->
 | 20 درصد | ۲۰ درصد | Persian digits |
+<!-- fa-lint-ignore-next-line -->
 | سال 2026 | سال ۲۰۲۶ | Persian digits |

--- a/scripts/fa_lint.py
+++ b/scripts/fa_lint.py
@@ -161,7 +161,9 @@ def fix_aggressive(text):
     return text
 
 def _skip_token(tok):
-    """Tokens whose digits must stay Latin: URLs, emails, paths, versions, code."""
+    """Tokens whose digits must stay Latin or are Unicode codepoint notation."""
+    if re.search(r'U\+[0-9A-Fa-f]{4,6}(?:\.\.)?', tok):
+        return True
     return bool(re.search(r'https?://|www\.|@|[/\\]|\.[a-z]{2,}|`', tok)
                 or re.fullmatch(r'\+?\d+(\.\d+)+[.,;،]?', tok))   # versions like 6.5
 
@@ -186,8 +188,25 @@ TANVIN_FA = {'گاهاً': 'گاهی', 'گاها': 'گاهی', 'دوماً': 'د
              'سوماً': 'سوم اینکه / ثالثاً', 'ناچاراً': 'به‌ناچار', 'زباناً': 'به زبان',
              'تلفناً': 'تلفنی', 'خواهشاً': 'خواهش می‌کنم'}
 
+def _lint_ignored_lines(text):
+    """Return line numbers suppressed by fa-lint directives."""
+    lines = text.split('\n')
+    ignored = set()
+
+    for i, line in enumerate(lines):
+        if '<!-- fa-lint-ignore-next-line -->' in line:
+            if i + 1 < len(lines):
+                ignored.add(i + 2)
+
+    return ignored
+
+
 def check_remaining(text):
+    ignored_lines = _lint_ignored_lines(text)
+
     for i, line in enumerate(text.split('\n'), 1):
+        if i in ignored_lines:
+            continue
         if not re.search(FA_LETTER, line):
             continue
         for ch, name in [('—', 'em dash'), ('–', 'en dash')]:
@@ -219,7 +238,9 @@ def check_remaining(text):
             record('hekasre', i, line,
                    f'«{m.group(0).strip()}» ends a clause with a kasre — predicate «است» '
                    f'is written «{m.group(1)}ه» (خوبه), not with ـِ')
-        if re.search(r'(?<=[' + PERSIAN + r'])\s*[,;?]|[,;?]\s*(?=[' + PERSIAN + r'])', line):
+        # Report ASCII punctuation only when it separates Persian text.
+        # Do not flag English prose that contains an isolated Persian character.
+        if re.search(r'[' + PERSIAN + r']\s*[,;?]\s*[' + PERSIAN + r']', line):
             record('latin-punct', i, line, 'Latin ,;? in Persian context → ، ؛ ؟')
         for a in ARABIC_MAP:
             if a in line:
@@ -232,8 +253,11 @@ def check_remaining(text):
             record('zwnj-tar', i, line, 'comparative تر/ترین: use ZWNJ (بزرگ‌تر)')
         if re.search(r'"[^"\n]*' + FA_LETTER, line):
             record('quotes', i, line, 'straight quotes around Persian → «گیومه»')
-        # ASCII digits touching Persian words (not urls/emails/versions/code)
-        for tok in line.split():
+        # ASCII digits touching Persian words (not urls/emails/versions/code).
+        # Markdown heading/list markers are structure, not prose.
+        digit_line = re.sub(r'^\s{0,3}#{1,6}\s+\d+[.)]\s+', '', line)
+        digit_line = re.sub(r'^\s*\d+[.)]\s+', '', digit_line)
+        for tok in digit_line.split():
             if (re.search(r'[0-9]', tok) and re.search(FA_LETTER, line)
                     and not _skip_token(tok)):
                 record('latin-digits', i, line, f'{tok}: Persian digits in Persian prose (or --digits)')
@@ -329,9 +353,15 @@ def main():
             label = 'remaining (need manual/contextual fixes)'
         else:
             check_remaining(text)
-            # also surface what --fix WOULD change
-            fixed = fix_safe(text)
-            if fixed != text:
+            # Also surface what --fix WOULD change, but respect lint suppressions.
+            ignored_lines = _lint_ignored_lines(text)
+            fixable_lines = [
+                '' if i in ignored_lines else line
+                for i, line in enumerate(text.split('\n'), 1)
+            ]
+            fixable_text = '\n'.join(fixable_lines)
+            fixed = fix_safe(fixable_text)
+            if fixed != fixable_text:
                 record('fixable', 0, '(multiple)', 'safe auto-fixes available: rerun with --fix')
             label = 'issues'
 

--- a/universal/persian-writing-universal.md
+++ b/universal/persian-writing-universal.md
@@ -646,7 +646,7 @@ typed-in-a-hurry one. Readers may not name the rule, but they feel it. All of
 this is enforceable: the persian_cleanup script (full package; chat-only AIs apply the equivalent rules manually) --edit` fixes the mechanical
 layer automatically; the fa_lint script (full package; chat-only AIs apply the equivalent rules manually) --check` reports what needs judgment.
 
-## 1. ZWNJ — نیم‌فاصله (U+200C)
+## 1. ZWNJ: نیم‌فاصله (U+200C)
 
 The zero-width non-joiner separates morphemes *without* a visual gap while
 preventing letter joining. Writing a full space (or nothing) instead is the
@@ -657,19 +657,25 @@ Required ZWNJ positions:
 
 | Pattern | Wrong | Right |
 |---|---|---|
+<!-- fa-lint-ignore-next-line -->
 | می/نمی + verb | می شود، نمی توانم، میشود* | می‌شود، نمی‌توانم |
+<!-- fa-lint-ignore-next-line -->
 | Plural ها | کتاب ها، سایت های | کتاب‌ها، سایت‌های |
+<!-- fa-lint-ignore-next-line -->
 | تر / ترین | بزرگ تر، مهم ترین | بزرگ‌تر، مهم‌ترین |
+<!-- fa-lint-ignore-next-line -->
 | Enclitic pronouns after ه | خانه ام، پروژه اش | خانه‌ام، پروژه‌اش |
 | Compound prefixes | بی دقت، هم زمان | بی‌دقت، هم‌زمان |
 | Compound words | وب سایت، صفحه بندی، نرم افزار | وب‌سایت، صفحه‌بندی، نرم‌افزار |
+<!-- fa-lint-ignore-next-line -->
 | ای after ه | حرفه ای، هفته ای | حرفه‌ای، هفته‌ای |
 
+<!-- fa-lint-ignore-next-line -->
 *میشود (fully attached) is acceptable only in colloquial register (میشه);
 in formal text always می‌شود.
 
 Lexicalized exceptions stay solid: همکار، بهتر، کمتر، بیشتر، امروزه، آنها
-(آن‌ها also correct — pick one per document).
+(آن‌ها also correct; pick one per document).
 
 ## 2. Persian characters, not Arabic
 
@@ -678,12 +684,16 @@ codepoints, break search, and render dotted/undotted wrongly:
 
 | Use (Persian) | Never (Arabic) |
 |---|---|
+<!-- fa-lint-ignore-next-line -->
 | ی U+06CC | ي U+064A |
+<!-- fa-lint-ignore-next-line -->
 | ک U+06A9 | ك U+0643 |
+<!-- fa-lint-ignore-next-line -->
 | ۀ/هٔ (or ه‌ی) | ة U+0629 |
+<!-- fa-lint-ignore-next-line -->
 | ۴۵۶ U+06F4.. | ٤٥٦ U+0664.. |
 
-ه with hamza: خانهٔ من or خانه‌ی من — both accepted; be consistent per document.
+ه with hamza: خانهٔ من or خانه‌ی من. Both are accepted. Be consistent per document.
 
 ## 3. Digits
 
@@ -692,24 +702,30 @@ codepoints, break search, and render dotted/undotted wrongly:
 - Latin digits stay Latin inside: URLs, emails, phone numbers meant for
   international dialing (+98...), code, version strings (WordPress 6.5),
   file names.
+<!-- fa-lint-ignore-next-line -->
 - Never Arabic-Indic variants (٤ ٥ ٦).
 - Percent: «۲۰٪» (U+066A) or «۲۰ درصد». In RTL both orders render fine if the
   digits are Persian; with Latin digits «20%» the run flips LTR.
-- Thousands separator: ٬ (U+066C) or، comma-free spacing — one style per doc.
+- Thousands separator: ٬ (U+066C) or، comma-free spacing. Use one style per doc.
 
 ## 4. Punctuation
 
 | Persian | Replaces | Note |
 |---|---|---|
+<!-- fa-lint-ignore-next-line -->
 | ، U+060C | , | comma |
+<!-- fa-lint-ignore-next-line -->
 | ؛ U+061B | ; | semicolon |
+<!-- fa-lint-ignore-next-line -->
 | ؟ U+061F | ? | question mark |
+<!-- fa-lint-ignore-next-line -->
 | «...» | "..." | quotes (گیومه) |
 | … | ... | ellipsis, or سه‌نقطه |
 
 Rules:
 - No space *before* punctuation, one space *after*: «درست، مثل این.»
-- ! stays ! — but one, never !!!
+<!-- fa-lint-ignore-next-line -->
+- ! stays !. Use one, never !!!
 - Em/en dashes: not used in Persian prose. Use «،» «؛» ( ) or restructure.
 - Latin fragments inside Persian (brand names, code) keep Latin punctuation
   *inside the fragment*: «افزونه WooCommerce، نسخه‌ی ۹».
@@ -722,7 +738,7 @@ Write it explicitly only where the host word demands it:
 - After ا and و: صدای بلند، عموی من (the ی is mandatory)
 - Diacritic کسره (ِ) only for disambiguation in formal/educational text.
 
-### 5.1 هکسره — the error Iranians mock most
+### 5.1 هکسره: the error Iranians mock most
 
 Two different things sound identical at the end of a word, so writers swap them.
 Getting this wrong in public copy is the single fastest way to look careless:
@@ -730,7 +746,7 @@ Iranians screenshot هکسره mistakes off billboards and brand accounts for sp
 
 | | What it is | Written | Example |
 |---|---|---|---|
-| **کسره‌ی اضافه** | links a noun to what follows (ezafe) | kasre — usually left unwritten, never «ه» | کتابِ من / کتاب من |
+| **کسره‌ی اضافه** | links a noun to what follows (ezafe) | kasre, usually left unwritten, never «ه» | کتابِ من / کتاب من |
 | **«ـه» clitic** | colloquial short form of «است» (predicate) | attached «ه» | این کتابه = این کتاب است |
 
 **The test that always works:** replace the ending with «است» and read it aloud.
@@ -738,38 +754,43 @@ If the sentence still makes sense, the correct spelling is «ـه». If it turns
 nonsense, you need a kasre (and usually write nothing at all).
 
 - «این کتابه» ← «این کتاب است» ✓ → «ـه» correct
+<!-- fa-lint-ignore-next-line -->
 - «کتابه من» ← «کتاب است من» ✗ → ezafe needed: **کتابِ من** (or plain «کتاب من»)
 
 **Wrong → right:**
 
 | ❌ | ✅ | Why |
 |---|---|---|
+<!-- fa-lint-ignore-next-line -->
 | کتابه من رو ندیدی؟ | کتابِ من رو ندیدی؟ | ezafe, not «است» |
 | کلاسه زبان می‌رم | کلاسِ زبان می‌رم | ezafe |
+<!-- fa-lint-ignore-next-line -->
 | قیمته این محصول چنده؟ | قیمتِ این محصول چنده؟ | first is ezafe, second («چنده») is «است» ✓ |
+<!-- fa-lint-ignore-next-line -->
 | سایته شرکت بالا نمیاد | سایتِ شرکت بالا نمیاد | ezafe |
-| هوا خیلی خوبِ | هوا خیلی خوبه | predicate «است» — the reverse error |
+| هوا خیلی خوبِ | هوا خیلی خوبه | predicate «است». This is the reverse error. |
+<!-- fa-lint-ignore-next-line -->
 | ماشینه من خرابه | ماشینِ من خرابه | ezafe first, «است» second ✓ |
 
-**Careful — these are NOT errors.** Many nouns simply end in ه, and they take a
+**Careful: these are NOT errors.** Many nouns simply end in ه, and they take a
 normal ezafe like any other word: خانه، نامه، برنامه، پروژه، مقاله، هفته، تجربه،
 شماره، بچه. «نامه شما رسید» and «پروژه‌ی شما» are both fine; nothing was swapped.
 
 **Register note:** the «ـه» clitic belongs to colloquial writing only. In formal
-or academic text write «است» in full — «این کتاب است»، not «این کتابه». So a
+or academic text write «است» in full. Use «این کتاب است», not «این کتابه». So a
 formal document that contains «ـه» clitics has a register problem, not just an
 orthography one (see writing-style.md).
 
 the fa_lint script (full package; chat-only AIs apply the equivalent rules manually) --check` flags probable هکسره in both directions. It reports
 rather than auto-fixes, because only context decides which of two identical
-sounds the writer meant — and a wrong "fix" here changes the meaning.
+sounds the writer meant. A wrong "fix" here changes the meaning.
 
 ## 6. Spacing hygiene
 
 - Exactly one space between words; no double spaces (common AI artifact).
 - No space inside «گیومه» : «درست»، نه « غلط ».
 - Parentheses: بیرون فاصله، داخل نه (مثل این).
-- Latin↔Persian boundary: one space — «پلتفرم WordPress برای...».
+- Latin↔Persian boundary: one space: «پلتفرم WordPress برای...».
 
 ## 7. Numbers as words
 
@@ -782,13 +803,20 @@ Formal prose: one-word numbers under eleven often spelled out (سه پیشنها
 |---|---|---|
 | میخواهم | می‌خواهم | ZWNJ after می |
 | آنها را دیدم ولی کتابها نه | آن‌ها ... کتاب‌ها | ZWNJ before ها (if using آن‌ها style) |
+<!-- fa-lint-ignore-next-line -->
 | عليرضا | علیرضا | Arabic ي |
+<!-- fa-lint-ignore-next-line -->
 | لطفا | لطفاً | tanvin on Arabic loan |
-| گاهاً | گاهی | tanvin on Persian word — always wrong |
+<!-- fa-lint-ignore-next-line -->
+| گاهاً | گاهی | tanvin on Persian word; always wrong |
+<!-- fa-lint-ignore-next-line -->
 | دوماً | دوم اینکه / ثانیاً | same |
 | بсمت | به سمت / به‌سمت | mashed preposition |
+<!-- fa-lint-ignore-next-line -->
 | "نقل قول" | «نقل قول» | گیومه |
+<!-- fa-lint-ignore-next-line -->
 | 20 درصد | ۲۰ درصد | Persian digits |
+<!-- fa-lint-ignore-next-line -->
 | سال 2026 | سال ۲۰۲۶ | Persian digits |
 
 


### PR DESCRIPTION
## Summary

* Fix Unicode codepoint handling in the Persian linter.
* Add support for `fa-lint-ignore-next-line` for intentional invalid examples.
* Improve Latin punctuation and digit detection.
* Regenerate the universal package.
* Keep version 1.3.5 consistent across the project.

## Validation

* Version check: passed
* Targeted Persian lint: passed
* Universal build: passed
* `git diff --check`: passed
* CLI smoke tests: passed
